### PR TITLE
fix: typos, COVID content, nav, analytics, local SEO H1s (LAC-2006)

### DIFF
--- a/components/Menu.jsx
+++ b/components/Menu.jsx
@@ -12,6 +12,8 @@ const Menu = (props) => (
 				<li><Link href="/couples"><span onClick={props.onToggleMenu}>Couples Therapy</span></Link></li>
 				<li><Link href="/family"><span onClick={props.onToggleMenu}>Family Counseling</span></Link></li>
 				<li><Link href="/online"><span onClick={props.onToggleMenu}>Online Therapy</span></Link></li>
+				<li><Link href="/coaching"><span onClick={props.onToggleMenu}>Life Coaching</span></Link></li>
+				<li><Link href="/intensives"><span onClick={props.onToggleMenu}>Couples Intensives</span></Link></li>
 			</ul>
 			<ul className="actions vertical">
 				<li><a href="#contact" onClick={props.onToggleMenu} className="button special fit">Contact</a></li>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,12 +1,14 @@
 import '../styles/skeleton.css'
 import '../styles/main.scss'
-// import { Analytics } from '@vercel/analytics/react';
+import { Analytics } from '@vercel/analytics/react';
 
 
 function App({ Component, pageProps }) {
   return (
-    <Component {...pageProps} />
-    // <Analytics />
+    <>
+      <Component {...pageProps} />
+      <Analytics />
+    </>
   )
 }
 export default App

--- a/pages/coaching.jsx
+++ b/pages/coaching.jsx
@@ -13,11 +13,11 @@ const Coaching = () => <Layout>
             <div className="inner">
                 <header className="major">
                     <h1>Life Coaching</h1>
-                    <blockquote>Help with love, business, and family relationshps.</blockquote>
+                    <blockquote>Help with love, business, and family relationships.</blockquote>
                 </header>
                 <span className="image main"><img src="/images/pic11.jpg" alt="Life coaching session for personal and professional growth" /></span>
                 <p>Bring a renewed desire for your best life, and collaboratively we will customize an action plan to get you on the path to the life you want. I offer goal focused, strategic intervention, and positive psychology strategies to address blocks to your success in relationships, work, and life.</p>
-                <p>Coaching is different from therapy, in that it is more specifically action and future oriented, rather than psychodynamically processing early and current inluences, with change efforts based on new insights and thought processes. If you have questions I am happy to discuss the best approach to your situation. I offer personal coaching, relationship coaching, family business coaching, and divorce coaching.</p>
+                <p>Coaching is different from therapy, in that it is more specifically action and future oriented, rather than psychodynamically processing early and current influences, with change efforts based on new insights and thought processes. If you have questions I am happy to discuss the best approach to your situation. I offer personal coaching, relationship coaching, family business coaching, and divorce coaching.</p>
             </div>
         </section>
     </div>

--- a/pages/couples.jsx
+++ b/pages/couples.jsx
@@ -12,7 +12,7 @@ const Couples = () => <Layout>
 		<section id="one">
 			<div className="inner">
 				<header className="major">
-					<h1>Couples Therapy</h1>
+					<h1>Couples Therapy in Charlotte, NC</h1>
 					<blockquote>Develop a lasting, secure bond that provides joy through life&apos;s triumphs, and shelter through tough times. Help for deeper communication, intimacy, marital crisis, and marital enrichment. My 30 years experience working with couples, advanced training in both attachment-based couple therapy - Emotionally Focused Therapy (EFT) with the Gottman Institute, puts your relationships in safe hands.</blockquote>
 				</header>
 				<span className="image main"><img src="/images/header-couples-2.jpg" alt="Couples therapy session helping partners reconnect and improve communication" width="1200" height="600" /></span>

--- a/pages/family.jsx
+++ b/pages/family.jsx
@@ -12,8 +12,8 @@ const Family = () => <Layout>
 		<section id="one">
 			<div className="inner">
 				<header className="major">
-					<h1>Family Therapy</h1>
-					<blockquote>Support through family ruptures in challenging times. <br />Re-establish and strengthen family bonds. Develop support strategies for individual family members going through personal struggles. Become a family that suports the health and wellness of all members.</blockquote>
+					<h1>Family Therapy in Charlotte, NC</h1>
+					<blockquote>Support through family ruptures in challenging times. <br />Re-establish and strengthen family bonds. Develop support strategies for individual family members going through personal struggles. Become a family that supports the health and wellness of all members.</blockquote>
 				</header>
 				<span className="image main"><img src="/images/header-family-2.jpg" alt="Family therapy session helping families reconnect and build stronger relationships" width="1200" height="600" /></span>
 				<p>With 30 years of experience as a licensed therapist, I have the training and a practical road map to lead you from stuck places of disconnection into a secure, loving bond. We will work together to build a sustainable bond, to help you to cope in this challenging world.</p>

--- a/pages/individual.jsx
+++ b/pages/individual.jsx
@@ -12,7 +12,7 @@ const Individual = () => <Layout>
 		<section id="one">
 			<div className="inner">
 				<header className="major">
-					<h1>Individual Therapy</h1>
+					<h1>Individual Therapy in Charlotte, NC</h1>
 					<blockquote>Help with Anxiety, Depression, Family Issues, Addictions, Trauma, and Loss.</blockquote>
 				</header>
 				<span className="image main"><img src="/images/header-individual-2.jpg" alt="Individual therapy session in Charlotte, North Carolina" width="1200" height="600" /></span>

--- a/pages/online.jsx
+++ b/pages/online.jsx
@@ -12,7 +12,7 @@ const Online = () => <Layout>
         <section id="one">
             <div className="inner">
                 <header className="major">
-                    <h1>Online Therapy</h1>
+                    <h1>Online Therapy for NC Residents</h1>
                     <blockquote>Remote counseling for the digital age</blockquote>
                 </header>
                 <span className="image main"><img src="/images/header-video.jpg" alt="Online therapy session via secure video conferencing" width="1200" height="600" /></span>

--- a/pages/weekend.jsx
+++ b/pages/weekend.jsx
@@ -17,7 +17,7 @@ const Weekend = () => <Layout>
                 </header>
                 <span className="image main"><img src="/images/pic11.jpg" alt="" /></span>
                 <p>If your relationship needs focused attention, you are experiencing strained communication, or even signs of distress, don’t leave your relationship untended. I offer a two-day, 8- hour, weekend intensive for couples. This in- person experience includes instruction, support, and guidance through progressive series of conversations. Each conversation takes couples a step forward, to rebuild intimacy for a lifetime of love.</p>
-                <p>During covid-19 quarantine, in person couple intensives are on temporary hold. Contact me by email susan@susanmorrow.us to get on the waiting list for future dates. I appreciate your patience.</p>
+                <p>Weekend intensives are scheduled by appointment. Contact me at <a href="mailto:susan@susanmorrow.us">susan@susanmorrow.us</a> to discuss availability and book your session.</p>
             </div>
         </section>
     </div>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -46,6 +46,11 @@
 	<priority>0.80</priority>
 </url>
 <url>
+	<loc>https://www.susanmorrow.us/weekend</loc>
+	<lastmod>2026-05-21T00:00:00+00:00</lastmod>
+	<priority>0.70</priority>
+</url>
+<url>
 	<loc>https://www.susanmorrow.us/privacy</loc>
 	<lastmod>2026-05-19T00:00:00+00:00</lastmod>
 	<priority>0.30</priority>


### PR DESCRIPTION
## Summary

Paperclip issue: [LAC-2006](https://paperclip/LAC/issues/LAC-2006) (parent: LAC-1999)

Bundle of small SEO + UX fixes to stop losing clients:

- **Typos** — `pages/coaching.jsx` (relationshps→relationships, inluences→influences), `pages/family.jsx` (suports→supports)
- **Stale COVID copy** — `pages/weekend.jsx` "in person couple intensives are on temporary hold" replaced with current booking info pointing to susan@susanmorrow.us
- **Hidden nav** — `components/Menu.jsx` now includes Life Coaching (/coaching) and Couples Intensives (/intensives), which previously had pages but no link
- **Analytics** — `pages/_app.jsx` now imports and renders `@vercel/analytics/react`
- **Local-SEO H1s** — Couples / Individual / Family H1s now say "in Charlotte, NC"; Online says "for NC Residents"
- **Sitemap** — `/weekend` added to `public/sitemap.xml`

## Test plan

- [x] `pnpm build` succeeds; all 19 static pages generated, including /weekend
- [ ] Visual check on dev server across viewports
- [ ] Verify Vercel Analytics fires after deploy
- [ ] Confirm new menu links work on mobile and desktop