### PR TITLE
perf: migrate images to next/image for Core Web Vitals (LAC-2010)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@ module.exports = {
   sassOptions: {
     silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin'],
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'gottmanreferralnetwork.com',
+        pathname: '/**',
+      },
+    ],
+  },
   async redirects() {
 		if (process.env.NODE_ENV === 'development') {
 			return [

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -31,7 +31,7 @@ const About = () => <Layout>
 			</section>
 			<section id="two" className="spotlights">
 				<section>
-					<div className="image"><img src="/images/headshot-2023-2.jpg" alt="Susan Morrow, Charlotte therapist" width="800" height="1200" /></div>
+					<div className="image"><Image src="/images/headshot-2023-2.jpg" alt="Susan Morrow, Charlotte therapist" width={800} height={1200} sizes="(max-width: 736px) 100vw, 40vw" /></div>
 					<div className="content">
 						<div className="inner">
 							<header className="major">
@@ -52,7 +52,7 @@ const About = () => <Layout>
 				</section>
 				<section>
 
-					<span className="image"><img src="/images/block-about-4.jpg" alt="Professional affiliations and certifications" width="476" height="453" /></span>
+					<span className="image"><Image src="/images/block-about-4.jpg" alt="Professional affiliations and certifications" width={476} height={453} sizes="(max-width: 736px) 100vw, 40vw" /></span>
 
 					<div className="content">
 						<div className="inner">
@@ -76,7 +76,7 @@ const About = () => <Layout>
 				</section>
 				<section>
 
-					<span className="image"><img src="/images/block-about-1.jpg" alt="Publications and research contributions" width="800" height="1200" /></span>
+					<span className="image"><Image src="/images/block-about-1.jpg" alt="Publications and research contributions" width={800} height={1200} sizes="(max-width: 736px) 100vw, 40vw" /></span>
 
 					<div className="content">
 						<div className="inner">

--- a/pages/coaching.jsx
+++ b/pages/coaching.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Coaching = () => <Layout>
                     <h1>Life Coaching</h1>
                     <blockquote>Help with love, business, and family relationshps.</blockquote>
                 </header>
-                <span className="image main"><img src="/images/pic11.jpg" alt="Life coaching session for personal and professional growth" /></span>
+                <span className="image main"><Image src="/images/pic11.jpg" alt="Life coaching session for personal and professional growth" width={864} height={259} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
                 <p>Bring a renewed desire for your best life, and collaboratively we will customize an action plan to get you on the path to the life you want. I offer goal focused, strategic intervention, and positive psychology strategies to address blocks to your success in relationships, work, and life.</p>
                 <p>Coaching is different from therapy, in that it is more specifically action and future oriented, rather than psychodynamically processing early and current inluences, with change efforts based on new insights and thought processes. If you have questions I am happy to discuss the best approach to your situation. I offer personal coaching, relationship coaching, family business coaching, and divorce coaching.</p>
             </div>

--- a/pages/couples.jsx
+++ b/pages/couples.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Couples = () => <Layout>
 					<h1>Couples Therapy</h1>
 					<blockquote>Develop a lasting, secure bond that provides joy through life&apos;s triumphs, and shelter through tough times. Help for deeper communication, intimacy, marital crisis, and marital enrichment. My 30 years experience working with couples, advanced training in both attachment-based couple therapy - Emotionally Focused Therapy (EFT) with the Gottman Institute, puts your relationships in safe hands.</blockquote>
 				</header>
-				<span className="image main"><img src="/images/header-couples-2.jpg" alt="Couples therapy session helping partners reconnect and improve communication" width="1200" height="600" /></span>
+				<span className="image main"><Image src="/images/header-couples-2.jpg" alt="Couples therapy session helping partners reconnect and improve communication" width={1200} height={600} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
 				<p>Even the most distressed couples can restore their love relationships to renewed intimacy and marital satisfaction. I use the most highly regarded, evidence–based couples therapy approach available in North America. Based on 40 years of research by esteemed marriage expert John Gottman, PhD (The Gottman Institute, University of Washington) and the couples therapy processes of Emotionally–Focused Therapy developed by eminent attachment science researcher, Sue Johnson, PhD.</p>
 				<p>With many years of experience as a couples therapist, I have the training and a practical road map to lead you from stuck places of disconnection into a secure, loving bond. We will work together to build a sustainable bond, to help you to cope in this challenging world.</p>
 				<p>Most marital distress comes from disconnection, communication problems, physical intimacy issues, broken trust, old hurts, stem from fissures in the couples basic attachment bond. I have a road map to take you out of these stuck places and into a more responsive, attuned, engaged relationship.</p>

--- a/pages/family.jsx
+++ b/pages/family.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Family = () => <Layout>
 					<h1>Family Therapy</h1>
 					<blockquote>Support through family ruptures in challenging times. <br />Re-establish and strengthen family bonds. Develop support strategies for individual family members going through personal struggles. Become a family that suports the health and wellness of all members.</blockquote>
 				</header>
-				<span className="image main"><img src="/images/header-family-2.jpg" alt="Family therapy session helping families reconnect and build stronger relationships" width="1200" height="600" /></span>
+				<span className="image main"><Image src="/images/header-family-2.jpg" alt="Family therapy session helping families reconnect and build stronger relationships" width={1200} height={600} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
 				<p>With 30 years of experience as a licensed therapist, I have the training and a practical road map to lead you from stuck places of disconnection into a secure, loving bond. We will work together to build a sustainable bond, to help you to cope in this challenging world.</p>
 				<p>Family therapy is about helping everyone in the family feel heard, understood, and supported. Instead of focusing on just one person, it looks at how the whole family works together. It gives you a safe space to talk through challenges, clear up misunderstandings, and strengthen your connections with one another.</p>
 				<p>Along the way, families learn helpful skills—like how to communicate better, solve problems together, and handle stress or big life changes as a team. These tools don’t just help right now; they prepare your family to face the future with more confidence and unity.</p>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,8 +4,8 @@ Life Strategies, Successful Transitions, Navigating Relationships, Help with Anx
 Goal-focused Coping Tools. Individual Therapy. Life Coaching.
 */
 
-/* eslint-disable @next/next/no-img-element */
 import Link from 'next/link'
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 import Banner from '../components/Banner'
@@ -54,7 +54,7 @@ const Index = () => <Layout>
 					<div className="row">
 						<div className="4u 12u$(small)">
 							<span className="image fit">
-								<img src="/images/headshot-2023-chair.jpg" alt="Susan Morrow, licensed clinical social worker in Charlotte NC" width="800" height="968" />
+								<Image src="/images/headshot-2023-chair.jpg" alt="Susan Morrow, licensed clinical social worker in Charlotte NC" width={800} height={968} sizes="(max-width: 736px) 100vw, 33vw" />
 							</span>
 						</div>
 						<div className="8u 12u$(small)">
@@ -75,16 +75,16 @@ const Index = () => <Layout>
 										<li><Link href="/about" className="button next">About Susan</Link></li>
 										<li>
 											<a target="_blank" rel="noopener noreferrer" href="https://www.psychologytoday.com/profile/51938" className="sx-verified-seal button special flex align-center">
-												<img style={{ width: 'auto', maxWidth: '155px' }} src="/images/logo-psychology-today.svg" alt="Susan Morrow on Psychology Today" width="155" height="50" />
+												<Image style={{ width: 'auto', maxWidth: '155px', height: 'auto' }} src="/images/logo-psychology-today.svg" alt="Susan Morrow on Psychology Today" width={155} height={50} unoptimized />
 											</a>
 										</li>
 									</ul>
 								</div>
 								<span className="image right" style={{ textAlign: 'center', display: 'flex', alignItems: 'center', flexDirection: 'column', gap: '2rem' }}>
 
-									<a href="https://www.gottman.com/" target="_blank" rel="noopener noreferrer" style={{ border: 'none' }}><img alt="Gottman Institute approved therapist badge" src="https://gottmanreferralnetwork.com/grn-badge-approved.png" style={{ width: '150px' }} width="150" height="150" /></a>
+									<a href="https://www.gottman.com/" target="_blank" rel="noopener noreferrer" style={{ border: 'none' }}><Image alt="Gottman Institute approved therapist badge" src="https://gottmanreferralnetwork.com/grn-badge-approved.png" style={{ width: '150px', height: 'auto' }} width={150} height={150} loading="lazy" /></a>
 									<a href="https://iceeft.com/" target="_blank" rel="noopener noreferrer" style={{ display: "flex", flexDirection: 'column', alignItems: 'center', border: 'none' }}>
-										<img src="/images/iceeft.png" alt="ICEEFT certified therapist" style={{ width: '150px' }} width="150" height="150" loading="lazy" />
+										<Image src="/images/iceeft.png" alt="ICEEFT certified therapist" style={{ width: '150px', height: 'auto' }} width={150} height={150} loading="lazy" />
 										<sub><i>International Centre for Emotionally Focused Therapy</i></sub>
 									</a>
 								</span>

--- a/pages/individual.jsx
+++ b/pages/individual.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Individual = () => <Layout>
 					<h1>Individual Therapy</h1>
 					<blockquote>Help with Anxiety, Depression, Family Issues, Addictions, Trauma, and Loss.</blockquote>
 				</header>
-				<span className="image main"><img src="/images/header-individual-2.jpg" alt="Individual therapy session in Charlotte, North Carolina" width="1200" height="600" /></span>
+				<span className="image main"><Image src="/images/header-individual-2.jpg" alt="Individual therapy session in Charlotte, North Carolina" width={1200} height={600} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
 
 				<p>Individual therapy provides a supportive platform for introspection and personal growth. It encourages the exploration and processing of life experiences, thereby aiding in the cultivation of a more integrated and secure sense of self. As this sense of identity solidifies, the path towards a life that is reflective of your inherent values becomes increasingly evident.</p>
 				<p>Our therapeutic approach is grounded in a variety of evidence-based methodologies, drawing from Emotionally Focused Therapy, Acceptance and Commitment Therapy (ACT), Cognitive Behavioral Therapy (CBT), Depth Psychology, Family Systems, Trauma-Informed, and Psychodynamic approaches. This eclectic approach ensures that our therapeutic strategies are tailored to best address your distinct needs and circumstances.</p>

--- a/pages/intensives.jsx
+++ b/pages/intensives.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Intensives = () => <Layout>
                     <h1>Couples Intensives</h1>
                     <blockquote>Structured 4 Hours of Couples Therapy</blockquote>
                 </header>
-                <span className="image main"><img src="/images/header-couples-2.jpg" alt="Couples intensive therapy session for relationship repair and enrichment" /></span>
+                <span className="image main"><Image src="/images/header-couples-2.jpg" alt="Couples intensive therapy session for relationship repair and enrichment" width={1440} height={433} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
                 <p>This is a helpful format for couples who have had a marital crisis and need focused attention on repair to their relationship, Pre-marital Couples, and Couples seeking Relationship Enrichment.</p>
             </div>
         </section>

--- a/pages/online.jsx
+++ b/pages/online.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Online = () => <Layout>
                     <h1>Online Therapy</h1>
                     <blockquote>Remote counseling for the digital age</blockquote>
                 </header>
-                <span className="image main"><img src="/images/header-video.jpg" alt="Online therapy session via secure video conferencing" width="1200" height="600" /></span>
+                <span className="image main"><Image src="/images/header-video.jpg" alt="Online therapy session via secure video conferencing" width={1200} height={600} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
                 <p>We live our lives in a digital age. While in person time is comforting and desirable, it’s at times not practical.</p>
                 <p>I am available to work with you through online or telephone services to optimize our therapy progress. Online therapy uses the same process you might expect at in-person meetings. If for some reason we are unable to meet in-person, I provide these services to help you get the support you need.</p>
                 <p>I am licensed in NC, and am available to NC residents for online individual, couples, and family therapy.</p>

--- a/pages/weekend.jsx
+++ b/pages/weekend.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import Image from 'next/image'
 
 import Layout from '../components/Layout'
 
@@ -15,7 +16,7 @@ const Weekend = () => <Layout>
                     <h1>Couples Intensive Therapy</h1>
                     <blockquote>Weekend intensive session are available for faster progress, scheduling convenience.</blockquote>
                 </header>
-                <span className="image main"><img src="/images/pic11.jpg" alt="" /></span>
+                <span className="image main"><Image src="/images/pic11.jpg" alt="" width={864} height={259} priority sizes="(max-width: 736px) 100vw, 75vw" style={{ width: '100%', height: 'auto' }} /></span>
                 <p>If your relationship needs focused attention, you are experiencing strained communication, or even signs of distress, don’t leave your relationship untended. I offer a two-day, 8- hour, weekend intensive for couples. This in- person experience includes instruction, support, and guidance through progressive series of conversations. Each conversation takes couples a step forward, to rebuild intimacy for a lifetime of love.</p>
                 <p>During covid-19 quarantine, in person couple intensives are on temporary hold. Contact me by email susan@susanmorrow.us to get on the waiting list for future dates. I appreciate your patience.</p>
             </div>


### PR DESCRIPTION
## Summary

- Replaces every `<img>` tag in the homepage, about page, and the seven service pages with `next/image` so Next.js can serve WebP/AVIF, lazy-load, prevent layout shift, and emit responsive `srcset`.
- Adds `remotePatterns` for `gottmanreferralnetwork.com` so the Gottman badge can flow through the image optimizer.
- Flags above-the-fold images (service-page headers + Psychology Today badge) as `priority`, keeps below-the-fold ones lazy.
- Adds explicit `width`/`height` to images that had none (coaching, intensives, weekend) so the optimizer can reserve space without CLS.

Paperclip: [LAC-2010](/LAC/issues/LAC-2010)

## Files touched

- `next.config.js` — `images.remotePatterns`
- `pages/index.jsx`, `pages/about.jsx`
- `pages/couples.jsx`, `pages/individual.jsx`, `pages/family.jsx`, `pages/online.jsx`
- `pages/coaching.jsx`, `pages/intensives.jsx`, `pages/weekend.jsx`

## Notes

- Each migrated `<Image>` keeps `style={{ width: '100%', height: 'auto' }}` where the parent CSS (`.image.main`) forces full-width, so the intrinsic aspect ratio is preserved.
- The Psychology Today SVG uses `unoptimized` (SVG, no optimizer benefit).
- `pages/landing.jsx` still uses `<img>`; out of scope per the issue.

## Test plan

- [x] `pnpm build` (Next.js 15.5.18) — succeeds, all 19 pages prerender.
- [x] `pnpm dev` smoke — `/`, `/about`, `/couples`, `/individual`, `/family`, `/online`, `/coaching`, `/intensives`, `/weekend` all return 200.
- [ ] Manual viewport pass (mobile / tablet / desktop) at review time.
- [ ] Lighthouse / CWV check after deploy to confirm LCP + CLS improvement.