### PR TITLE
refactor: modernize Next.js Link usage in Menu.jsx (LAC-2037)

### DIFF
--- a/components/Menu.jsx
+++ b/components/Menu.jsx
@@ -1,27 +1,21 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 
-// <li><Link href="/documents"><a><span onClick={props.onToggleMenu}>Documents</span></a></Link></li>
 const Menu = (props) => (
 	<nav id="menu">
 		<div className="inner">
 			<ul className="links">
-				<li><Link href="/"><span onClick={props.onToggleMenu}>Home</span></Link></li>
-				<li><Link href="/about"><span onClick={props.onToggleMenu}>About</span></Link></li>
-				<li><Link href="/individual"><span onClick={props.onToggleMenu}>Individual Therapy</span></Link></li>
-				<li><Link href="/couples"><span onClick={props.onToggleMenu}>Couples Therapy</span></Link></li>
-				<li><Link href="/family"><span onClick={props.onToggleMenu}>Family Counseling</span></Link></li>
-				<li><Link href="/online"><span onClick={props.onToggleMenu}>Online Therapy</span></Link></li>
-				<li><Link href="/coaching"><span onClick={props.onToggleMenu}>Life Coaching</span></Link></li>
-				<li><Link href="/intensives"><span onClick={props.onToggleMenu}>Couples Intensives</span></Link></li>
+				<li><Link href="/" onClick={props.onToggleMenu}>Home</Link></li>
+				<li><Link href="/about" onClick={props.onToggleMenu}>About</Link></li>
+				<li><Link href="/individual" onClick={props.onToggleMenu}>Individual Therapy</Link></li>
+				<li><Link href="/couples" onClick={props.onToggleMenu}>Couples Therapy</Link></li>
+				<li><Link href="/family" onClick={props.onToggleMenu}>Family Counseling</Link></li>
+				<li><Link href="/online" onClick={props.onToggleMenu}>Online Therapy</Link></li>
+				<li><Link href="/coaching" onClick={props.onToggleMenu}>Life Coaching</Link></li>
+				<li><Link href="/intensives" onClick={props.onToggleMenu}>Couples Intensives</Link></li>
 			</ul>
 			<ul className="actions vertical">
 				<li><a href="#contact" onClick={props.onToggleMenu} className="button special fit">Contact</a></li>
-				{/* <li>
-                    <Link href="/covid">
-                        <a onClick={props.onToggleMenu} className="button fit">COVID-19 Care</a>
-                    </Link>
-                </li> */}
 			</ul>
 		</div>
 		<a className="close" onClick={props.onToggleMenu} href="#" aria-label="Close menu">Close</a>


### PR DESCRIPTION
## Summary

Drops the legacy `<Link><span onClick>Label</span></Link>` wrapper pattern in `components/Menu.jsx` in favor of the Next.js 13+ recommended `<Link onClick>Label</Link>` pattern. Also removes the stale commented-out legacy snippet at the top and an unused commented COVID-19 link block.

Paperclip issue: [LAC-2037](https://paperclip.com/LAC/issues/LAC-2037)
Parent: LAC-1999
Follow-up from post-merge feedback on [LAC-2006](https://paperclip.com/LAC/issues/LAC-2006) (PR #35).

## Changes

- All 8 nav `<Link>` rows now attach `onClick={props.onToggleMenu}` directly to `<Link>` and render the label as the child text node — no extra wrapping `<span>`.
- Removed the stale commented-out legacy `<Link><a><span>Documents</span></a></Link>` example on line 4.
- Removed the commented-out COVID-19 Care block (also legacy `<Link><a>` shape).

## Why

- Cleaner DOM (no extra `<span>` per nav item).
- Aligns with Next.js 13+ `<Link>` API — the component already renders the `<a>`.
- Removes legacy patterns that prompted the local-board SEO follow-up.

Not a correctness or SEO bug — purely a small modernization.

## Acceptance

- [x] No nested `<span>` inside `<Link>` in `Menu.jsx`.
- [ ] Menu toggle still closes the menu on click in dev (manual verification recommended).
- [ ] No console warning about nested anchors (manual verification recommended).

## Test plan

- [ ] Run `pnpm dev` (or repo's dev command), open the mobile/menu toggle, click each nav link and confirm the menu closes and navigation works.
- [ ] Check browser console for any "validateDOMNesting" or nested-anchor warnings.