### PR TITLE
fix: banner hero text touching viewport edge (LAC-2256)

### DIFF
--- a/styles/layout/_banner.scss
+++ b/styles/layout/_banner.scss
@@ -60,8 +60,11 @@
         "-webkit-filter 0.5s ease"
       )
     );
+    margin: 0 auto;
+    max-width: _size(inner);
     padding: 0 !important;
     position: relative;
+    width: calc(100% - 6em);
     z-index: 2;
 
     .image {
@@ -174,6 +177,8 @@
     }
 
     > .inner {
+      width: calc(100% - 3em);
+
       .content {
         display: block;
 


### PR DESCRIPTION
## Summary
- The banner hero `.inner` container had no width constraint or centering, causing the "About Susan Morrow" heading to sit flush against the left viewport edge
- Root cause: Next.js wraps page content in `<main>` and `<div>` elements, making `.inner` 4 levels deep from `#wrapper` — the wrapper mixin's `#wrapper > * > .inner` selector (2 levels) never matched
- Added explicit `width: calc(100% - 6em)`, `max-width`, and `margin: 0 auto` to `#banner > .inner`, with a `calc(100% - 3em)` override for small breakpoints

## Test plan
- [x] Desktop: hero text is inset from viewport edges, aligned with content below
- [x] Mobile (375px): hero text has proper horizontal spacing
- [x] Homepage banner: no regression
- [x] Landing page: no regression
- [x] Build passes