### PR TITLE
fix: add 301 redirects for broken legacy URLs (LAC-2430)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,17 +3,36 @@ module.exports = {
     silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin'],
   },
   async redirects() {
+		const redirects = [
+			// Old WordPress-era pages → current equivalents
+			{ source: '/contact', destination: '/', permanent: true },
+			{ source: '/services', destination: '/', permanent: true },
+			{ source: '/online-therapy', destination: '/online', permanent: true },
+			{ source: '/individuals', destination: '/individual', permanent: true },
+			{ source: '/life-coaching', destination: '/coaching', permanent: true },
+			{ source: '/seminars', destination: '/intensives', permanent: true },
+			{ source: '/crew', destination: '/about', permanent: true },
+			// Old static HTML pages
+			{ source: '/Contact.html', destination: '/', permanent: true },
+			{ source: '/Contact.php', destination: '/', permanent: true },
+			{ source: '/Bio.html', destination: '/about', permanent: true },
+			{ source: '/about.html', destination: '/about', permanent: true },
+			{ source: '/Couples.html', destination: '/couples', permanent: true },
+			{ source: '/Services.html', destination: '/', permanent: true },
+			{ source: '/Location.html', destination: '/about', permanent: true },
+			{ source: '/Welcome.html', destination: '/', permanent: true },
+			{ source: '/Bookstore.html', destination: '/', permanent: true },
+		]
+
 		if (process.env.NODE_ENV === 'development') {
-			return [
-				{
-					source: '/elements',
-					destination: '/',
-					permanent: false,
-				},
-			]
+			redirects.push({
+				source: '/elements',
+				destination: '/',
+				permanent: false,
+			})
 		}
 
-		return []
+		return redirects
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary

- Added 16 permanent 301 redirects in `next.config.js` for old WordPress-era and static HTML URLs that currently return 404 or produce broken redirect chains (308 → 404)
- Fixes Ahrefs Health Score issues: broken redirects, 4XX pages receiving organic traffic, and redirect target changes
- Key redirects: `/contact` → `/`, `/services` → `/`, `/online-therapy` → `/online`, `/individuals` → `/individual`, `/life-coaching` → `/coaching`, plus legacy `.html`/`.php` pages

## Problem

Ahrefs Site Audit (2026-06-15) flagged susanmorrow.us at Health Score **33** due to:
- **Broken redirects** (2 URLs): trailing-slash URLs like `/contact/` redirect via 308 to `/contact` which returns 404
- **4XX pages receiving organic traffic** (2 URLs): old pages like `/contact`, `/services`, `/online-therapy` still get search traffic but return 404
- **Redirect target changed**: old paths from WordPress era no longer resolve

## Redirect mapping

| Old URL | → | Current page | Rationale |
|---------|---|-------------|-----------|
| `/contact` | → | `/` | Contact form is in global Layout on every page |
| `/services` | → | `/` | Home page lists all services |
| `/online-therapy` | → | `/online` | Renamed page |
| `/individuals` | → | `/individual` | Plural → singular |
| `/life-coaching` | → | `/coaching` | Renamed page |
| `/seminars` | → | `/intensives` | Closest equivalent |
| `/crew` | → | `/about` | Old team page |
| `/Contact.html`, `/Contact.php` | → | `/` | Legacy static site |
| `/Bio.html`, `/about.html` | → | `/about` | Legacy static site |
| `/Couples.html` | → | `/couples` | Legacy static site |
| `/Services.html`, `/Welcome.html`, `/Bookstore.html` | → | `/` | Legacy static site |
| `/Location.html` | → | `/about` | About has address |

## Test plan

- [x] `next build` succeeds
- [x] Redirect config validates via `node -e "require('./next.config.js').redirects().then(console.log)"`
- [ ] After deploy: `curl -sI https://www.susanmorrow.us/contact` returns 301 → `/`
- [ ] After deploy: `curl -sI https://www.susanmorrow.us/online-therapy` returns 301 → `/online`
- [ ] Re-run Ahrefs Site Audit and confirm Health Score recovers