### PR TITLE
LAC-2784: link orphan + optimize slow page on susanmorrow.com

### DIFF
--- a/components/Menu.jsx
+++ b/components/Menu.jsx
@@ -13,6 +13,7 @@ const Menu = (props) => (
 				<li><Link href="/online" onClick={props.onToggleMenu}>Online Therapy</Link></li>
 				<li><Link href="/coaching" onClick={props.onToggleMenu}>Life Coaching</Link></li>
 				<li><Link href="/intensives" onClick={props.onToggleMenu}>Couples Intensives</Link></li>
+				<li><Link href="/weekend" onClick={props.onToggleMenu}>Weekend Intensives</Link></li>
 			</ul>
 			<ul className="actions vertical">
 				<li><a href="#contact" onClick={props.onToggleMenu} className="button special fit">Contact</a></li>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -45,7 +45,7 @@ const Index = () => <Layout>
 
 		<div id="main">
 			<section id="one" className="tiles">
-				<article style={{ backgroundImage: `url('/images/block-individual-3.jpg')` }}>
+				<article style={{ backgroundImage: `url('/images/block-individual-2.jpg')` }}>
 					<header className="major">
 						<h3>Individual Therapy</h3>
 						<p>Help for Anxiety, Depression, Family Issues, Addictions, Trauma, and Loss.</p>


### PR DESCRIPTION
## Summary

Small-sites SEO cleanup for [LAC-2784](https://paperclip.ing/issues/LAC-2784).

**Orphan page fixed:** `/weekend` (Weekend Intensives) was in the sitemap and indexable but had no internal links anywhere in the site. Added it to the main navigation `Menu.jsx` under Couples Intensives, its natural parent.

**Slow page fixed:** The home page tile for Individual Therapy was loading `block-individual-3.jpg` at **3.2MB** as a CSS background image, while its sibling tiles use images ~58-150KB. Swapped in the already-optimized `block-individual-2.jpg` (65KB) — same subject, ~98% smaller. Should meaningfully improve LCP on the home page.

## Test plan
- [ ] Verify `/weekend` link appears in the mobile/hamburger menu
- [ ] Verify Individual Therapy tile on the home page still displays a photo
- [ ] Re-crawl in Ahrefs to confirm the orphan and slow-page issues clear